### PR TITLE
v2.1.0 — full imperial unit support

### DIFF
--- a/sensor-package/migraine_sensors.yaml
+++ b/sensor-package/migraine_sensors.yaml
@@ -221,15 +221,26 @@ template:
         state: >
           {% set weather_entity = states('input_text.migraine_source_weather') %}
           {% set temp_entity = states('input_text.migraine_source_temperature') %}
+          {% macro to_celsius(v, source_entity=None) %}
+            {% set f = v | float(0) %}
+            {% set unit = state_attr(source_entity, 'unit_of_measurement') if source_entity else None %}
+            {% if unit in ['°F','F','fahrenheit'] or (unit is none and f > 50) %}
+              {{ ((f - 32) * 5 / 9) | round(2) }}
+            {% else %}
+              {{ f }}
+            {% endif %}
+          {% endmacro %}
           {% if temp_entity not in ['not_configured','unknown','unavailable','',none] %}
             {% set v = states(temp_entity) %}
             {% if v not in ['unknown','unavailable','',none] %}
-              {{ v | float(0) }}
+              {{ to_celsius(v, temp_entity) | trim }}
             {% else %}
-              {{ state_attr(weather_entity, 'temperature') | float(0) }}
+              {% set wa = state_attr(weather_entity, 'temperature') %}
+              {{ to_celsius(wa) | trim if wa is number else 0 }}
             {% endif %}
           {% elif weather_entity not in ['not_configured','unknown','unavailable','',none] %}
-            {{ state_attr(weather_entity, 'temperature') | float(0) }}
+            {% set wa = state_attr(weather_entity, 'temperature') %}
+            {{ to_celsius(wa) | trim if wa is number else 0 }}
           {% else %}
             {{ 0 }}
           {% endif %}
@@ -265,6 +276,8 @@ template:
             {% set f = v | float(0) %}
             {% if f >= 25 and f <= 33 %}
               {{ (f * 33.8639) | round(2) }}
+            {% elif f >= 600 and f <= 825 %}
+              {{ (f * 1.33322) | round(2) }}
             {% else %}
               {{ f }}
             {% endif %}
@@ -293,15 +306,31 @@ template:
         state: >
           {% set weather_entity = states('input_text.migraine_source_weather') %}
           {% set wind_entity = states('input_text.migraine_source_wind_speed') %}
+          {% macro to_kmh(v, source_entity=None) %}
+            {% set f = v | float(0) %}
+            {% set unit = state_attr(source_entity, 'unit_of_measurement') if source_entity else None %}
+            {% set weather_unit = state_attr(weather_entity, 'wind_speed_unit') if weather_entity not in ['not_configured','unknown','unavailable','',none] else None %}
+            {% if unit in ['mph','MPH'] or (source_entity is none and weather_unit == 'mph') %}
+              {{ (f * 1.60934) | round(2) }}
+            {% elif unit in ['m/s','meters_per_second'] or (source_entity is none and weather_unit == 'm/s') %}
+              {{ (f * 3.6) | round(2) }}
+            {% elif unit in ['knots','kn','kt'] or (source_entity is none and weather_unit in ['kn','knots']) %}
+              {{ (f * 1.852) | round(2) }}
+            {% else %}
+              {{ f }}
+            {% endif %}
+          {% endmacro %}
           {% if wind_entity not in ['not_configured','unknown','unavailable','',none] %}
             {% set v = states(wind_entity) %}
             {% if v not in ['unknown','unavailable','',none] %}
-              {{ v | float(0) }}
+              {{ to_kmh(v, wind_entity) | trim }}
             {% else %}
-              {{ state_attr(weather_entity, 'wind_speed') | float(0) }}
+              {% set wa = state_attr(weather_entity, 'wind_speed') %}
+              {{ to_kmh(wa) | trim if wa is number else 0 }}
             {% endif %}
           {% elif weather_entity not in ['not_configured','unknown','unavailable','',none] %}
-            {{ state_attr(weather_entity, 'wind_speed') | float(0) }}
+            {% set wa = state_attr(weather_entity, 'wind_speed') %}
+            {{ to_kmh(wa) | trim if wa is number else 0 }}
           {% else %}
             {{ 0 }}
           {% endif %}

--- a/src/migraine-risk-card.js
+++ b/src/migraine-risk-card.js
@@ -1,5 +1,5 @@
 /**
- * Migraine Risk Card v2.0.3
+ * Migraine Risk Card v2.1.0
  * Home Assistant Custom Lovelace Card
  *
  * Works two ways:
@@ -15,7 +15,7 @@
  * © 2026 — MIT Licence
  */
 
-const CARD_VERSION = '2.0.3';
+const CARD_VERSION = '2.1.0';
 
 console.info(
   `%c🧠 Migraine Risk Card %cv${CARD_VERSION}`,
@@ -176,6 +176,22 @@ function parseNum(val) {
 function fmtNum(n) {
   if (n == null) return '?';
   return n % 1 === 0 ? String(n) : n.toFixed(1);
+}
+
+function convertToImperial(factorKey, metricValue) {
+  switch (factorKey) {
+    case 'pressure_6h':
+    case 'pressure_24h':
+      return { value: metricValue * 0.02953, unit: ' inHg' };
+    case 'temperature':
+      return { value: metricValue * 9 / 5 + 32, unit: '°F' };
+    case 'temperature_change':
+      return { value: metricValue * 9 / 5, unit: '°F' };
+    case 'wind':
+      return { value: metricValue / 1.60934, unit: ' mph' };
+    default:
+      return null;
+  }
 }
 
 function ensureFonts() {
@@ -697,6 +713,11 @@ class MigraineRiskCard extends HTMLElement {
     if (key === 'thunderstorm') return STORM_DISPLAY[st] || st;
     const n = parseNum(st);
     if (n == null) return st;
+    const imperial = this._config.displayUnits === 'imperial';
+    if (imperial) {
+      const conv = convertToImperial(key, n);
+      if (conv) return fmtNum(conv.value) + conv.unit;
+    }
     const unit = entity.attributes?.unit_of_measurement || def.unit || '';
     return fmtNum(n) + unit;
   }
@@ -862,6 +883,9 @@ class MigraineRiskCardEditor extends HTMLElement {
       weatherFields
     ));
 
+    // ── Section: Display ──
+    container.appendChild(this._displaySection());
+
     sr.appendChild(container);
     this._rendered = true;
 
@@ -871,6 +895,52 @@ class MigraineRiskCardEditor extends HTMLElement {
         p.hass = this._hass;
       });
     }
+  }
+
+  _displaySection() {
+    const section = document.createElement('div');
+    section.className = 'section';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'section-title';
+    titleEl.innerHTML = '<ha-icon icon="mdi:tune"></ha-icon> Display';
+    section.appendChild(titleEl);
+
+    const hintEl = document.createElement('div');
+    hintEl.className = 'hint';
+    hintEl.textContent = 'Internal scoring is always metric; only what you see on the card changes.';
+    hintEl.style.marginBottom = '12px';
+    section.appendChild(hintEl);
+
+    const field = document.createElement('div');
+    field.className = 'field';
+    const lbl = document.createElement('div');
+    lbl.className = 'field-label';
+    lbl.textContent = 'Display Units';
+    field.appendChild(lbl);
+
+    const select = document.createElement('ha-select');
+    select.value = this._config.displayUnits || 'metric';
+    select.label = 'Display Units';
+    ['metric', 'imperial'].forEach(v => {
+      const item = document.createElement('mwc-list-item');
+      item.value = v;
+      item.textContent = v === 'metric' ? 'Metric (°C, km/h, hPa)' : 'Imperial (°F, mph, inHg)';
+      select.appendChild(item);
+    });
+    select.addEventListener('selected', (e) => {
+      const val = e.target?.value || 'metric';
+      if (val === 'metric') {
+        delete this._config.displayUnits;
+      } else {
+        this._config.displayUnits = val;
+      }
+      this._fire();
+    });
+    field.appendChild(select);
+
+    section.appendChild(field);
+    return section;
   }
 
   _section(icon, title, hint, fields) {


### PR DESCRIPTION
## Summary

Closes #7. The card and sensor package now properly support US/UK installs with non-metric weather sources. PR #19 in v2.0.3 covered inHg → hPa; this release extends that to wind (mph, m/s, knots) and temperature (°F), plus adds mmHg pressure support for users in regions that report in mmHg.

## How it works

**Sensor package** normalises everything to metric on ingestion. The risk score and all thresholds stay metric, so no scoring logic had to change. Detection prefers the source entity's `unit_of_measurement` attribute, falls back to range heuristics for attribute-only sources (e.g. `weather.*` integrations).

| Macro | Detects | Conversion |
|---|---|---|
| `to_celsius` | `unit = °F`, or value > 50° | `(f - 32) * 5/9` |
| `to_kmh` | `unit = mph` (or `wind_speed_unit` on weather entity) | `× 1.60934` |
| `to_kmh` | `unit = m/s` | `× 3.6` |
| `to_kmh` | `unit = knots` | `× 1.852` |
| `to_hpa` | inHg (25–33 range) | `× 33.8639` (already in 2.0.3) |
| `to_hpa` | mmHg (600–825 range) | `× 1.33322` (new — raised by @undel-gh) |

**Card** adds a `displayUnits` config option (`'metric'` | `'imperial'`, default `'metric'`). When `imperial`, the card displays wind in mph, current temperature in °F, temperature change in °F (delta, no offset), and pressure deltas in inHg. Conversion happens at render time only — the entity values and risk score are unchanged.

The editor exposes the option as a dropdown in a new Display section.

## Test plan

- [x] Sensor package validates with `ha_check_config`
- [ ] Configure a `weather.*` integration that reports °F + mph + inHg; confirm card shows correct values and risk score matches a metric-only setup
- [ ] Toggle `displayUnits` in the editor; confirm units change live without affecting score

## Issues closed

- #7 — Metric labels appear to be hard coded

🤖 Generated with [Claude Code](https://claude.com/claude-code)