### PR TITLE
Document pre-v2.0.3 upgrade path

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,30 @@ entity_air_quality: sensor.migraine_factor_air_quality
 
 All factor entities are optional — the card only displays what you configure. If you installed the sensor package with the default settings, the entity names above will work without any changes.
 
+## Upgrading from a pre-v2.0.3 install
+
+> **⚠️ Read this if you installed any version before v2.0.3.**
+
+Versions before v2.0.3 had a bug where Home Assistant sluggified `name: "Migraine Temperature (°C)"` into `sensor.migraine_temperature_degc` (and similarly `sensor.migraine_wind_speed_km_h`), but the scoring templates referenced `sensor.migraine_temperature` / `sensor.migraine_wind_speed`. The result: temperature and wind factors silently returned 0 and your risk score was wrong.
+
+**v2.0.3 fixes the YAML** so fresh installs get the correct entity IDs. But Home Assistant locks `unique_id → entity_id` mappings in the entity registry on first registration, so **just updating the YAML doesn't rename your existing entities** — you need a one-time manual rename.
+
+### One-time fix (preserves history)
+
+For each affected entity:
+
+1. **Settings → Devices & Services → Entities**
+2. Search `migraine_temperature_degc`
+3. Click it → click the cog icon (top right)
+4. Change **Entity ID** from `sensor.migraine_temperature_degc` to `sensor.migraine_temperature`
+5. Click **Update**
+6. Repeat for wind: search `migraine_wind_speed_km_h` → rename to `sensor.migraine_wind_speed`
+7. Reload templates (**Developer Tools → YAML → Template Entities**) or restart HA
+
+After that, the v2.0.3 YAML works as intended — templates find the right entities, the temperature-baseline automation runs, and the risk score scores correctly.
+
+**Not sure if you're affected?** Go to **Developer Tools → States** and search `migraine_temperature`. If you see `sensor.migraine_temperature_degc` (with the `_degc` suffix), you need the fix. If you see `sensor.migraine_temperature` cleanly, you're fine — either you're on a fresh v2.0.3+ install or you already manually renamed it.
+
 ## Configuring Data Sources
 
 The sensor package uses `input_text` helpers to store your entity mappings. This makes it easy to change your data sources at any time without editing YAML — just update the helper value in the UI and the sensors will pick up the new source automatically.


### PR DESCRIPTION
Closes follow-up to v2.0.3 surfaced via #21 (Daniel-MFG) and #24 (BenKuch).

v2.0.3 renamed the template sensor `name:` attributes so HA derives the correct entity IDs for **fresh installs**. But HA stores `unique_id → entity_id` mappings in the entity registry on first registration, so users who installed pre-v2.0.3 still have `sensor.migraine_temperature_degc` and `sensor.migraine_wind_speed_km_h` locked in — updating the YAML alone doesn't rename them.

Adds an explicit "Upgrading from a pre-v2.0.3 install" section to the README with:
- Explanation of why the YAML update alone doesn't suffice
- One-time UI rename steps for the affected entities
- A check users can run to see if they're affected

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)